### PR TITLE
[codex] Add local MCP server

### DIFF
--- a/core/mcp/__init__.py
+++ b/core/mcp/__init__.py
@@ -1,0 +1,1 @@
+"""KapMan local read-only MCP server package."""

--- a/core/mcp/db/__init__.py
+++ b/core/mcp/db/__init__.py
@@ -1,0 +1,3 @@
+from . import queries
+
+__all__ = ["queries"]

--- a/core/mcp/db/connection.py
+++ b/core/mcp/db/connection.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+
+import psycopg2
+
+from core.db.a6_migrations import default_database_url
+
+
+def _readonly_database_url() -> str:
+    return os.getenv("DATABASE_URL") or default_database_url()
+
+
+@contextmanager
+def readonly_connection():
+    conn = psycopg2.connect(_readonly_database_url())
+    conn.autocommit = False
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SET TRANSACTION READ ONLY")
+        yield conn
+    finally:
+        conn.rollback()
+        conn.close()

--- a/core/mcp/db/queries.py
+++ b/core/mcp/db/queries.py
@@ -1,0 +1,315 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import Any, Optional
+
+
+def resolve_ticker(conn, symbol: str) -> Optional[dict[str, str]]:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT id::text, UPPER(symbol)
+            FROM public.tickers
+            WHERE UPPER(symbol) = UPPER(%s)
+            """,
+            (symbol,),
+        )
+        row = cur.fetchone()
+    if not row:
+        return None
+    return {"ticker_id": row[0], "symbol": row[1]}
+
+
+def has_active_watchlist_membership(conn, symbol: str) -> bool:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT 1
+            FROM public.watchlists
+            WHERE UPPER(symbol) = UPPER(%s) AND active = TRUE
+            LIMIT 1
+            """,
+            (symbol,),
+        )
+        return cur.fetchone() is not None
+
+
+def latest_snapshot_for_symbol(conn, *, ticker_id: str, as_of_date: Optional[date]) -> Optional[dict[str, Any]]:
+    params: list[Any] = [ticker_id]
+    where_date = ""
+    if as_of_date:
+        where_date = "AND ny_date <= %s"
+        params.append(as_of_date)
+
+    with conn.cursor() as cur:
+        cur.execute(
+            f"""
+            WITH ranked AS (
+                SELECT
+                    ds.*,
+                    (ds.time AT TIME ZONE 'America/New_York')::date AS ny_date,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY (ds.time AT TIME ZONE 'America/New_York')::date
+                        ORDER BY
+                            CASE WHEN ds.wyckoff_regime IS NULL THEN 1 ELSE 0 END ASC,
+                            ds.time DESC
+                    ) AS row_rank,
+                    COUNT(*) OVER (PARTITION BY (ds.time AT TIME ZONE 'America/New_York')::date) AS dup_count
+                FROM public.daily_snapshots ds
+                WHERE ds.ticker_id = %s
+            ), dedup AS (
+                SELECT *
+                FROM ranked
+                WHERE row_rank = 1
+                {where_date}
+            )
+            SELECT
+                time,
+                ny_date,
+                dup_count,
+                wyckoff_phase,
+                phase_confidence,
+                wyckoff_regime,
+                wyckoff_regime_confidence,
+                wyckoff_regime_set_by_event,
+                primary_event,
+                events_detected,
+                events_json,
+                technical_indicators_json,
+                dealer_metrics_json,
+                volatility_metrics_json,
+                price_metrics_json
+            FROM dedup
+            ORDER BY ny_date DESC, time DESC
+            LIMIT 1
+            """,
+            tuple(params),
+        )
+        row = cur.fetchone()
+
+    if not row:
+        return None
+
+    return {
+        "time": row[0],
+        "ny_date": row[1],
+        "dup_count": int(row[2] or 0),
+        "wyckoff_phase": row[3],
+        "phase_confidence": float(row[4]) if row[4] is not None else None,
+        "wyckoff_regime": row[5],
+        "wyckoff_regime_confidence": float(row[6]) if row[6] is not None else None,
+        "wyckoff_regime_set_by_event": row[7],
+        "primary_event": row[8],
+        "events_detected": row[9] or [],
+        "events_json": row[10],
+        "technical_indicators_json": row[11],
+        "dealer_metrics_json": row[12],
+        "volatility_metrics_json": row[13],
+        "price_metrics_json": row[14],
+    }
+
+
+def fetch_ohlcv_window(conn, *, ticker_id: str, start_date: date, end_date: date) -> list[dict[str, Any]]:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT date, open, high, low, close, volume
+            FROM public.ohlcv
+            WHERE ticker_id = %s AND date >= %s AND date <= %s
+            ORDER BY date ASC
+            """,
+            (ticker_id, start_date, end_date),
+        )
+        rows = cur.fetchall()
+    return [
+        {
+            "date": row[0].isoformat(),
+            "open": float(row[1]) if row[1] is not None else None,
+            "high": float(row[2]) if row[2] is not None else None,
+            "low": float(row[3]) if row[3] is not None else None,
+            "close": float(row[4]) if row[4] is not None else None,
+            "volume": int(row[5]) if row[5] is not None else None,
+        }
+        for row in rows
+    ]
+
+
+def fetch_regime_transitions(conn, *, ticker_id: str, end_date: date, limit: int = 20) -> list[dict[str, Any]]:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT date, prior_regime, new_regime, duration_bars
+            FROM public.wyckoff_regime_transitions
+            WHERE ticker_id = %s AND date <= %s
+            ORDER BY date DESC, new_regime ASC
+            LIMIT %s
+            """,
+            (ticker_id, end_date, limit),
+        )
+        rows = cur.fetchall()
+    return [
+        {"date": row[0].isoformat(), "prior_regime": row[1], "new_regime": row[2], "duration_bars": row[3]}
+        for row in rows
+    ]
+
+
+def fetch_sequences(conn, *, ticker_id: str, end_date: date, limit: int = 20) -> list[dict[str, Any]]:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT sequence_id, start_date, completion_date, events_in_sequence
+            FROM public.wyckoff_sequences
+            WHERE ticker_id = %s AND completion_date <= %s
+            ORDER BY completion_date DESC, sequence_id ASC
+            LIMIT %s
+            """,
+            (ticker_id, end_date, limit),
+        )
+        rows = cur.fetchall()
+    return [
+        {
+            "sequence_id": row[0],
+            "start_date": row[1].isoformat(),
+            "completion_date": row[2].isoformat(),
+            "events_in_sequence": row[3],
+        }
+        for row in rows
+    ]
+
+
+def fetch_sequence_events(conn, *, ticker_id: str, end_date: date, limit: int = 50) -> list[dict[str, Any]]:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT sequence_id, completion_date, event_type, event_date, event_role, event_order
+            FROM public.wyckoff_sequence_events
+            WHERE ticker_id = %s AND completion_date <= %s
+            ORDER BY completion_date DESC, event_order ASC
+            LIMIT %s
+            """,
+            (ticker_id, end_date, limit),
+        )
+        rows = cur.fetchall()
+    return [
+        {
+            "sequence_id": row[0],
+            "completion_date": row[1].isoformat(),
+            "event_type": row[2],
+            "event_date": row[3].isoformat(),
+            "event_role": row[4],
+            "event_order": row[5],
+        }
+        for row in rows
+    ]
+
+
+def fetch_context_events(conn, *, ticker_id: str, end_date: date, limit: int = 50) -> list[dict[str, Any]]:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT event_date, event_type, prior_regime, context_label
+            FROM public.wyckoff_context_events
+            WHERE ticker_id = %s AND event_date <= %s
+            ORDER BY event_date DESC, event_type ASC
+            LIMIT %s
+            """,
+            (ticker_id, end_date, limit),
+        )
+        rows = cur.fetchall()
+    return [
+        {
+            "event_date": row[0].isoformat(),
+            "event_type": row[1],
+            "prior_regime": row[2],
+            "context_label": row[3],
+        }
+        for row in rows
+    ]
+
+
+def fetch_snapshot_evidence(conn, *, ticker_id: str, end_date: date, limit: int = 20) -> list[dict[str, Any]]:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT date, evidence_json
+            FROM public.wyckoff_snapshot_evidence
+            WHERE ticker_id = %s AND date <= %s
+            ORDER BY date DESC
+            LIMIT %s
+            """,
+            (ticker_id, end_date, limit),
+        )
+        rows = cur.fetchall()
+    return [{"date": row[0].isoformat(), "evidence_json": row[1]} for row in rows]
+
+
+def screen_rows(conn, *, as_of_date: Optional[date]) -> list[dict[str, Any]]:
+    params: list[Any] = []
+    as_of_filter = ""
+    if as_of_date:
+        as_of_filter = "AND d.ny_date <= %s"
+        params.append(as_of_date)
+
+    with conn.cursor() as cur:
+        cur.execute(
+            f"""
+            WITH w AS (
+                SELECT DISTINCT UPPER(symbol) AS symbol
+                FROM public.watchlists
+                WHERE active = TRUE
+            ), t AS (
+                SELECT id::text AS ticker_id, UPPER(symbol) AS symbol
+                FROM public.tickers
+            ), d AS (
+                SELECT
+                    ds.ticker_id::text AS ticker_id,
+                    (ds.time AT TIME ZONE 'America/New_York')::date AS ny_date,
+                    ds.time,
+                    ds.wyckoff_regime,
+                    ds.primary_event,
+                    ds.dealer_metrics_json,
+                    ds.volatility_metrics_json,
+                    ds.price_metrics_json,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY ds.ticker_id
+                        ORDER BY (ds.time AT TIME ZONE 'America/New_York')::date DESC, ds.time DESC
+                    ) AS rn
+                FROM public.daily_snapshots ds
+            )
+            SELECT
+                t.symbol,
+                t.ticker_id,
+                d.ny_date,
+                d.wyckoff_regime,
+                d.primary_event,
+                d.dealer_metrics_json,
+                d.volatility_metrics_json,
+                d.price_metrics_json
+            FROM w
+            JOIN t ON t.symbol = w.symbol
+            LEFT JOIN d ON d.ticker_id = t.ticker_id AND d.rn = 1 {as_of_filter}
+            ORDER BY t.symbol ASC
+            """,
+            tuple(params),
+        )
+        rows = cur.fetchall()
+
+    result: list[dict[str, Any]] = []
+    for row in rows:
+        dealer = row[5] or {}
+        vol = row[6] or {}
+        price = row[7] or {}
+        result.append(
+            {
+                "symbol": row[0],
+                "ticker_id": row[1],
+                "snapshot_date": row[2].isoformat() if row[2] else None,
+                "regime": row[3],
+                "primary_event": row[4],
+                "dgpi": dealer.get("dgpi"),
+                "iv_rank": vol.get("iv_rank"),
+                "rvol": price.get("rvol"),
+                "has_snapshot": row[2] is not None,
+            }
+        )
+    return result

--- a/core/mcp/schema.py
+++ b/core/mcp/schema.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+CONFIRMATION_STATUS_UNCONFIRMED = "unconfirmed_pipeline_observation"
+
+DATA_QUALITY_FLAGS = (
+    "missing_snapshot",
+    "stale_snapshot",
+    "missing_ohlcv",
+    "missing_metric_category",
+    "duplicate_same_day_snapshots",
+    "missing_watchlist_membership",
+)
+
+METRIC_CATEGORY_TO_COLUMN = {
+    "price": "price_metrics_json",
+    "technical": "technical_indicators_json",
+    "volatility": "volatility_metrics_json",
+    "dealer": "dealer_metrics_json",
+}
+
+
+@dataclass(frozen=True)
+class DataQualityFlagSet:
+    missing_snapshot: bool = False
+    stale_snapshot: bool = False
+    missing_ohlcv: bool = False
+    missing_metric_category: bool = False
+    duplicate_same_day_snapshots: bool = False
+    missing_watchlist_membership: bool = False
+
+    def to_dict(self) -> dict[str, bool]:
+        return {
+            "missing_snapshot": self.missing_snapshot,
+            "stale_snapshot": self.stale_snapshot,
+            "missing_ohlcv": self.missing_ohlcv,
+            "missing_metric_category": self.missing_metric_category,
+            "duplicate_same_day_snapshots": self.duplicate_same_day_snapshots,
+            "missing_watchlist_membership": self.missing_watchlist_membership,
+        }

--- a/core/mcp/server.py
+++ b/core/mcp/server.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Literal, Optional
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from core.mcp.tools.metrics import get_metrics
+from core.mcp.tools.screen_watchlist import screen_watchlist
+from core.mcp.tools.wyckoff_proposal import get_wyckoff_proposal_context
+
+
+TOOLS: dict[str, Any] = {
+    "get_wyckoff_proposal_context": get_wyckoff_proposal_context,
+    "get_metrics": get_metrics,
+    "screen_watchlist": screen_watchlist,
+}
+
+
+def _tool_descriptors() -> list[dict[str, Any]]:
+    return [
+        {
+            "name": "get_wyckoff_proposal_context",
+            "description": "Build Wyckoff proposal context from persisted rows",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "symbol": {"type": "string"},
+                    "as_of_date": {"type": ["string", "null"]},
+                    "lookback_days": {"type": "integer", "default": 90},
+                },
+                "required": ["symbol"],
+            },
+        },
+        {
+            "name": "get_metrics",
+            "description": "Return normalized metrics from latest eligible snapshot",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "symbol": {"type": "string"},
+                    "as_of_date": {"type": ["string", "null"]},
+                    "include": {"type": ["array", "null"], "items": {"type": "string"}},
+                    "metric_keys": {"type": ["array", "null"], "items": {"type": "string"}},
+                },
+                "required": ["symbol"],
+            },
+        },
+        {
+            "name": "screen_watchlist",
+            "description": "Filter and rank persisted watchlist symbols",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "as_of_date": {"type": ["string", "null"]},
+                    "filters": {"type": ["object", "null"]},
+                    "limit": {"type": "integer", "default": 50},
+                },
+            },
+        },
+    ]
+
+
+def _write_message(payload: dict[str, Any], mode: Literal["mcp", "newline"]) -> None:
+    body = json.dumps(payload, default=str)
+    if mode == "newline":
+        sys.stdout.write(body + "\n")
+        sys.stdout.flush()
+        return
+
+    encoded = body.encode("utf-8")
+    sys.stdout.buffer.write(f"Content-Length: {len(encoded)}\r\n\r\n".encode("ascii"))
+    sys.stdout.buffer.write(encoded)
+    sys.stdout.buffer.flush()
+
+
+def _read_message() -> Optional[tuple[dict[str, Any], Literal["mcp", "newline"]]]:
+    first_line = sys.stdin.buffer.readline()
+    if not first_line:
+        return None
+
+    stripped = first_line.strip()
+    if stripped.startswith(b"{"):
+        return json.loads(stripped.decode("utf-8")), "newline"
+
+    headers: dict[str, str] = {}
+    line = first_line
+    while line and line not in (b"\r\n", b"\n"):
+        name, _, value = line.decode("ascii").partition(":")
+        headers[name.lower()] = value.strip()
+        line = sys.stdin.buffer.readline()
+
+    content_length = int(headers.get("content-length", "0"))
+    if content_length <= 0:
+        raise ValueError("missing Content-Length header")
+    body = sys.stdin.buffer.read(content_length)
+    return json.loads(body.decode("utf-8")), "mcp"
+
+
+def _reply(id_value: Any, mode: Literal["mcp", "newline"], result: Any = None, error: str | None = None) -> None:
+    payload: dict[str, Any] = {"jsonrpc": "2.0", "id": id_value}
+    if error is not None:
+        payload["error"] = {"code": -32000, "message": error}
+    else:
+        payload["result"] = result
+    _write_message(payload, mode)
+
+
+def serve_stdio() -> None:
+    while True:
+        req: dict[str, Any] = {}
+        mode: Literal["mcp", "newline"] = "mcp"
+        try:
+            read = _read_message()
+            if read is None:
+                return
+            req, mode = read
+            method = req.get("method")
+            req_id = req.get("id")
+            params = req.get("params") or {}
+            if method == "initialize":
+                _reply(
+                    req_id,
+                    mode,
+                    {
+                        "protocolVersion": params.get("protocolVersion", "2024-11-05"),
+                        "capabilities": {"tools": {}},
+                        "serverInfo": {"name": "kapman-mcp", "version": "0.1.0"},
+                    },
+                )
+            elif method == "notifications/initialized":
+                continue
+            elif method == "ping":
+                _reply(req_id, mode, {})
+            elif method == "tools/list":
+                _reply(req_id, mode, {"tools": _tool_descriptors()})
+            elif method == "tools/call":
+                name = params.get("name")
+                arguments = params.get("arguments") or {}
+                if name not in TOOLS:
+                    raise ValueError(f"unknown tool: {name}")
+                result = TOOLS[name](**arguments)
+                _reply(
+                    req_id,
+                    mode,
+                    {
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": json.dumps(result, default=str, indent=2, sort_keys=True),
+                            }
+                        ]
+                    },
+                )
+            else:
+                if req_id is not None:
+                    _reply(req_id, mode, error=f"unsupported method: {method}")
+        except Exception as exc:  # noqa: BLE001
+            _reply(req.get("id") if isinstance(req, dict) else None, mode, error=str(exc))
+
+
+if __name__ == "__main__":
+    serve_stdio()

--- a/core/mcp/tools/__init__.py
+++ b/core/mcp/tools/__init__.py
@@ -1,0 +1,5 @@
+from .metrics import get_metrics
+from .screen_watchlist import screen_watchlist
+from .wyckoff_proposal import get_wyckoff_proposal_context
+
+__all__ = ["get_metrics", "screen_watchlist", "get_wyckoff_proposal_context"]

--- a/core/mcp/tools/metrics.py
+++ b/core/mcp/tools/metrics.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Any, Optional
+
+from core.mcp.db.connection import readonly_connection
+from core.mcp.db import queries
+from core.mcp.schema import METRIC_CATEGORY_TO_COLUMN
+
+
+def _parse_date(value: Optional[str]) -> Optional[date]:
+    if value is None:
+        return None
+    try:
+        return datetime.strptime(value, "%Y-%m-%d").date()
+    except ValueError as exc:
+        raise ValueError("as_of_date must be YYYY-MM-DD") from exc
+
+
+def get_metrics(
+    symbol: str,
+    as_of_date: Optional[str] = None,
+    include: Optional[list[str]] = None,
+    metric_keys: Optional[list[str]] = None,
+) -> dict[str, Any]:
+    if not symbol or not symbol.strip():
+        raise ValueError("symbol is required")
+    requested = include or ["price", "technical", "volatility", "dealer"]
+    invalid = [k for k in requested if k not in METRIC_CATEGORY_TO_COLUMN]
+    if invalid:
+        raise ValueError(f"unsupported include categories: {invalid}")
+    parsed_date = _parse_date(as_of_date)
+
+    with readonly_connection() as conn:
+        ticker = queries.resolve_ticker(conn, symbol)
+        if not ticker:
+            raise ValueError(f"unknown symbol: {symbol}")
+        snap = queries.latest_snapshot_for_symbol(conn, ticker_id=ticker["ticker_id"], as_of_date=parsed_date)
+
+    result: dict[str, Any] = {
+        "symbol": ticker["symbol"],
+        "ticker_id": ticker["ticker_id"],
+        "effective_as_of_date": parsed_date.isoformat() if parsed_date else None,
+        "latest_eligible_snapshot_date": snap["ny_date"].isoformat() if snap else None,
+        "metrics": {},
+        "data_quality_flags": {
+            "missing_snapshot": snap is None,
+            "missing_metric_category": False,
+        },
+    }
+
+    if not snap:
+        for category in requested:
+            result["metrics"][category] = {}
+        if metric_keys:
+            for category in requested:
+                result["metrics"][category] = {k: None for k in metric_keys}
+        return result
+
+    any_missing_category = False
+    for category in requested:
+        blob = snap.get(METRIC_CATEGORY_TO_COLUMN[category]) or {}
+        if not blob:
+            any_missing_category = True
+        if metric_keys:
+            result["metrics"][category] = {k: blob.get(k) for k in metric_keys}
+        else:
+            result["metrics"][category] = blob
+    result["data_quality_flags"]["missing_metric_category"] = any_missing_category
+    return result

--- a/core/mcp/tools/screen_watchlist.py
+++ b/core/mcp/tools/screen_watchlist.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Any, Optional
+
+from core.mcp.db.connection import readonly_connection
+from core.mcp.db import queries
+
+
+def _parse_date(value: Optional[str]) -> Optional[date]:
+    if value is None:
+        return None
+    try:
+        return datetime.strptime(value, "%Y-%m-%d").date()
+    except ValueError as exc:
+        raise ValueError("as_of_date must be YYYY-MM-DD") from exc
+
+
+def _passes_list_filter(value: Optional[str], raw_filter: Any) -> bool:
+    if raw_filter is None:
+        return True
+    if isinstance(raw_filter, list):
+        includes = {str(v).upper() for v in raw_filter}
+        return (value or "").upper() in includes
+    if isinstance(raw_filter, dict):
+        includes = {str(v).upper() for v in raw_filter.get("include", [])}
+        excludes = {str(v).upper() for v in raw_filter.get("exclude", [])}
+        token = (value or "").upper()
+        if includes and token not in includes:
+            return False
+        if token in excludes:
+            return False
+        return True
+    raise ValueError("list filters must be list or object with include/exclude")
+
+
+def screen_watchlist(as_of_date: Optional[str] = None, filters: Optional[dict[str, Any]] = None, limit: int = 50) -> dict[str, Any]:
+    if limit <= 0:
+        raise ValueError("limit must be > 0")
+    parsed_date = _parse_date(as_of_date)
+    filters = filters or {}
+
+    with readonly_connection() as conn:
+        rows = queries.screen_rows(conn, as_of_date=parsed_date)
+
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        if not _passes_list_filter(row["regime"], filters.get("regime")):
+            continue
+        if not _passes_list_filter(row["primary_event"], filters.get("primary_event")):
+            continue
+
+        iv_rank = row.get("iv_rank")
+        dgpi = row.get("dgpi")
+        rvol = row.get("rvol")
+        if filters.get("iv_rank_min") is not None and (iv_rank is None or iv_rank < filters["iv_rank_min"]):
+            continue
+        if filters.get("iv_rank_max") is not None and (iv_rank is None or iv_rank > filters["iv_rank_max"]):
+            continue
+        if filters.get("dgpi_min") is not None and (dgpi is None or dgpi < filters["dgpi_min"]):
+            continue
+        if filters.get("rvol_min") is not None and (rvol is None or rvol < filters["rvol_min"]):
+            continue
+        if filters.get("exclude_missing_data") and (not row["has_snapshot"] or iv_rank is None or dgpi is None or rvol is None):
+            continue
+
+        out.append(row)
+
+    out.sort(key=lambda r: ((r.get("dgpi") is None), -(r.get("dgpi") or -10**9), r["symbol"]))
+    return {
+        "effective_as_of_date": parsed_date.isoformat() if parsed_date else None,
+        "count": min(len(out), limit),
+        "results": out[:limit],
+    }

--- a/core/mcp/tools/wyckoff_proposal.py
+++ b/core/mcp/tools/wyckoff_proposal.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+from typing import Any, Optional
+
+from core.mcp.db.connection import readonly_connection
+from core.mcp.db import queries
+from core.mcp.schema import CONFIRMATION_STATUS_UNCONFIRMED
+
+
+def _parse_date(value: Optional[str]) -> Optional[date]:
+    if value is None:
+        return None
+    try:
+        return datetime.strptime(value, "%Y-%m-%d").date()
+    except ValueError as exc:
+        raise ValueError("as_of_date must be YYYY-MM-DD") from exc
+
+
+def _extract_metrics(snapshot: dict[str, Any]) -> dict[str, Any]:
+    p = snapshot.get("price_metrics_json") or {}
+    t = snapshot.get("technical_indicators_json") or {}
+    v = snapshot.get("volatility_metrics_json") or {}
+    d = snapshot.get("dealer_metrics_json") or {}
+    return {
+        "price_metrics": {"rvol": p.get("rvol"), "vsi": p.get("vsi"), "hv": p.get("hv")},
+        "technical_metrics": {
+            "rsi": t.get("rsi"),
+            "macd": t.get("macd"),
+            "adx": t.get("adx"),
+            "obv": t.get("obv"),
+            "sma": t.get("sma"),
+            "ema": t.get("ema"),
+        },
+        "volatility_summary": {
+            "average_iv": v.get("average_iv"),
+            "iv_rank": v.get("iv_rank"),
+            "iv_percentile": v.get("iv_percentile"),
+            "iv_skew": v.get("iv_skew"),
+            "term_structure": v.get("term_structure"),
+            "put_call_ratio": v.get("put_call_ratio"),
+        },
+        "dealer_summary": {
+            "dgpi": d.get("dgpi"),
+            "net_gex": d.get("net_gex"),
+            "total_gex": d.get("total_gex"),
+            "gamma_flip": d.get("gamma_flip"),
+            "call_wall": d.get("call_wall"),
+            "put_wall": d.get("put_wall"),
+            "dealer_position": d.get("dealer_position"),
+        },
+    }
+
+
+def get_wyckoff_proposal_context(symbol: str, as_of_date: Optional[str] = None, lookback_days: int = 90) -> dict[str, Any]:
+    if not symbol or not symbol.strip():
+        raise ValueError("symbol is required")
+    if lookback_days <= 0:
+        raise ValueError("lookback_days must be > 0")
+    parsed_date = _parse_date(as_of_date)
+
+    with readonly_connection() as conn:
+        ticker = queries.resolve_ticker(conn, symbol)
+        if not ticker:
+            raise ValueError(f"unknown symbol: {symbol}")
+
+        snap = queries.latest_snapshot_for_symbol(conn, ticker_id=ticker["ticker_id"], as_of_date=parsed_date)
+        membership = queries.has_active_watchlist_membership(conn, ticker["symbol"])
+
+        if not snap:
+            return {
+                "symbol": ticker["symbol"],
+                "ticker_id": ticker["ticker_id"],
+                "effective_as_of_date": parsed_date.isoformat() if parsed_date else None,
+                "latest_eligible_snapshot_date": None,
+                "pipeline_reading": {
+                    "regime": None,
+                    "regime_confidence": None,
+                    "regime_setting_event": None,
+                    "primary_event": None,
+                    "events_detected": [],
+                    "confirmation_status": CONFIRMATION_STATUS_UNCONFIRMED,
+                },
+                "recent_events": [],
+                "ohlcv": [],
+                "price_metrics": {"rvol": None, "vsi": None, "hv": None},
+                "technical_metrics": {"rsi": None, "macd": None, "adx": None, "obv": None, "sma": None, "ema": None},
+                "volatility_summary": {"average_iv": None, "iv_rank": None, "iv_percentile": None, "iv_skew": None, "term_structure": None, "put_call_ratio": None},
+                "dealer_summary": {"dgpi": None, "net_gex": None, "total_gex": None, "gamma_flip": None, "call_wall": None, "put_wall": None, "dealer_position": None},
+                "regime_transitions": [],
+                "wyckoff_context_events": [],
+                "canonical_sequences": [],
+                "sequence_events": [],
+                "snapshot_evidence": [],
+                "structural_levels": {"support_candidates": [], "resistance_candidates": []},
+                "data_quality_flags": {
+                    "missing_snapshot": True,
+                    "stale_snapshot": False,
+                    "missing_ohlcv": True,
+                    "missing_metric_category": True,
+                    "duplicate_same_day_snapshots": False,
+                    "missing_watchlist_membership": not membership,
+                },
+            }
+
+        snapshot_date = snap["ny_date"]
+        start_date = snapshot_date - timedelta(days=lookback_days)
+        ohlcv = queries.fetch_ohlcv_window(conn, ticker_id=ticker["ticker_id"], start_date=start_date, end_date=snapshot_date)
+        transitions = queries.fetch_regime_transitions(conn, ticker_id=ticker["ticker_id"], end_date=snapshot_date)
+        context_events = queries.fetch_context_events(conn, ticker_id=ticker["ticker_id"], end_date=snapshot_date)
+        sequences = queries.fetch_sequences(conn, ticker_id=ticker["ticker_id"], end_date=snapshot_date)
+        sequence_events = queries.fetch_sequence_events(conn, ticker_id=ticker["ticker_id"], end_date=snapshot_date)
+        evidence = queries.fetch_snapshot_evidence(conn, ticker_id=ticker["ticker_id"], end_date=snapshot_date)
+
+    metrics = _extract_metrics(snap)
+    support = [bar["low"] for bar in ohlcv[-20:] if bar.get("low") is not None][-3:]
+    resistance = [bar["high"] for bar in ohlcv[-20:] if bar.get("high") is not None][-3:]
+    missing_metric_category = any(v is None for category in metrics.values() for v in category.values())
+
+    return {
+        "symbol": ticker["symbol"],
+        "ticker_id": ticker["ticker_id"],
+        "effective_as_of_date": (parsed_date or snapshot_date).isoformat(),
+        "latest_eligible_snapshot_date": snapshot_date.isoformat(),
+        "pipeline_reading": {
+            "regime": snap.get("wyckoff_regime"),
+            "regime_confidence": snap.get("wyckoff_regime_confidence"),
+            "regime_setting_event": snap.get("wyckoff_regime_set_by_event"),
+            "primary_event": snap.get("primary_event"),
+            "events_detected": snap.get("events_detected") or [],
+            "confirmation_status": CONFIRMATION_STATUS_UNCONFIRMED,
+        },
+        "recent_events": {
+            "primary_event": snap.get("primary_event"),
+            "events_detected": snap.get("events_detected") or [],
+            "events_json": snap.get("events_json"),
+        },
+        "ohlcv": ohlcv,
+        "price_metrics": metrics["price_metrics"],
+        "technical_metrics": metrics["technical_metrics"],
+        "volatility_summary": metrics["volatility_summary"],
+        "dealer_summary": metrics["dealer_summary"],
+        "regime_transitions": transitions,
+        "wyckoff_context_events": context_events,
+        "canonical_sequences": sequences,
+        "sequence_events": sequence_events,
+        "snapshot_evidence": evidence,
+        "structural_levels": {
+            "support_candidates": support,
+            "resistance_candidates": resistance,
+        },
+        "data_quality_flags": {
+            "missing_snapshot": False,
+            "stale_snapshot": bool(parsed_date and snapshot_date < parsed_date),
+            "missing_ohlcv": len(ohlcv) == 0,
+            "missing_metric_category": missing_metric_category,
+            "duplicate_same_day_snapshots": snap.get("dup_count", 0) > 1,
+            "missing_watchlist_membership": not membership,
+        },
+    }

--- a/docs/runbooks/kapman_mcp.md
+++ b/docs/runbooks/kapman_mcp.md
@@ -1,0 +1,34 @@
+# kapman-mcp (Local Read-Only MCP Server)
+
+## Start
+
+```bash
+python -m core.mcp.server
+```
+
+Transport is stdio only.
+
+## Required Environment Variables
+
+- `DATABASE_URL`
+
+## LLM Client Connection
+
+Connect an MCP-compatible client to the process command:
+
+- command: `python`
+- args: `-m core.mcp.server`
+- transport: `stdio`
+
+The server exposes exactly three tools:
+
+- `get_wyckoff_proposal_context`
+- `get_metrics`
+- `screen_watchlist`
+
+## Known Limitations
+
+- Read-only database access only.
+- No pipeline execution, ingestion, metrics jobs, or recommendation generation.
+- No write tools.
+- Wyckoff outputs are pipeline observations and always include `confirmation_status: "unconfirmed_pipeline_observation"`.

--- a/tests/integration/mcp/test_mcp_integration.py
+++ b/tests/integration/mcp/test_mcp_integration.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import os
+from datetime import date, datetime, timezone
+
+import psycopg2
+import pytest
+from psycopg2.extras import Json
+
+from core.db.a6_migrations import default_migrations_dir, reset_and_migrate
+from core.daily_snapshots import canonical_daily_snapshot_time
+from core.mcp.tools.metrics import get_metrics
+from core.mcp.tools.screen_watchlist import screen_watchlist
+from core.mcp.tools.wyckoff_proposal import get_wyckoff_proposal_context
+
+
+def _test_db_url() -> str | None:
+    return os.getenv("KAPMAN_TEST_DATABASE_URL")
+
+
+def _seed(conn):
+    now = datetime.now(timezone.utc)
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO public.tickers (id, symbol, name, created_at) VALUES (%s, %s, %s, %s)",
+            ("00000000-0000-0000-0000-000000000001", "AMD", "Advanced Micro Devices", now),
+        )
+        cur.execute(
+            "INSERT INTO public.watchlists (watchlist_id, symbol, active, source, effective_date) VALUES (%s,%s,%s,%s,%s)",
+            ("core", "AMD", True, "test", date(2026, 1, 10)),
+        )
+        cur.execute(
+            "INSERT INTO public.watchlists (watchlist_id, symbol, active, source, effective_date) VALUES (%s,%s,%s,%s,%s)",
+            ("core", "TSLA", True, "test", date(2026, 1, 10)),
+        )
+        cur.execute(
+            "INSERT INTO public.tickers (id, symbol, name, created_at) VALUES (%s, %s, %s, %s)",
+            ("00000000-0000-0000-0000-000000000002", "TSLA", "Tesla", now),
+        )
+
+        snap_time = canonical_daily_snapshot_time(date(2026, 1, 10))
+        dup_time = snap_time.replace(hour=23, minute=59, second=59, microsecond=999998)
+        cur.execute(
+            """
+            INSERT INTO public.daily_snapshots (
+                time, ticker_id, wyckoff_regime, wyckoff_regime_confidence, wyckoff_regime_set_by_event,
+                events_detected, primary_event, events_json, technical_indicators_json, dealer_metrics_json,
+                volatility_metrics_json, price_metrics_json, created_at
+            ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+            """,
+            (
+                dup_time,
+                "00000000-0000-0000-0000-000000000001",
+                None,
+                None,
+                None,
+                ["SC"],
+                "SC",
+                Json({"events": ["SC"]}),
+                Json({"rsi": 55.0}),
+                Json({"dgpi": 0.1}),
+                Json({"iv_rank": 0.4}),
+                Json({"rvol": 1.5}),
+                now,
+            ),
+        )
+        cur.execute(
+            """
+            INSERT INTO public.daily_snapshots (
+                time, ticker_id, wyckoff_regime, wyckoff_regime_confidence, wyckoff_regime_set_by_event,
+                events_detected, primary_event, events_json, technical_indicators_json, dealer_metrics_json,
+                volatility_metrics_json, price_metrics_json, created_at
+            ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+            """,
+            (
+                snap_time,
+                "00000000-0000-0000-0000-000000000001",
+                "MARKUP",
+                0.78,
+                "SOS",
+                ["SOS"],
+                "SOS",
+                Json({"events": ["SOS"]}),
+                Json({"rsi": 61.0, "macd": 1.2, "adx": 20.0, "obv": 1000, "sma": {"20": 120}, "ema": {"20": 121}}),
+                Json({"dgpi": 0.8, "net_gex": 1500}),
+                Json({"iv_rank": 0.6, "average_iv": 0.31, "put_call_ratio": 0.8}),
+                Json({"rvol": 1.8, "vsi": 1.1, "hv": 0.2}),
+                now,
+            ),
+        )
+        cur.execute(
+            """
+            INSERT INTO public.daily_snapshots (time, ticker_id, wyckoff_regime, primary_event, created_at)
+            VALUES (%s,%s,%s,%s,%s)
+            """,
+            (snap_time, "00000000-0000-0000-0000-000000000002", "ACCUMULATION", "SC", now),
+        )
+
+        cur.execute(
+            "INSERT INTO public.ohlcv (ticker_id, date, open, high, low, close, volume, created_at) VALUES (%s,%s,%s,%s,%s,%s,%s,%s)",
+            ("00000000-0000-0000-0000-000000000001", date(2026, 1, 9), 100, 110, 95, 108, 1000000, now),
+        )
+        cur.execute(
+            "INSERT INTO public.wyckoff_regime_transitions (ticker_id, date, prior_regime, new_regime, duration_bars) VALUES (%s,%s,%s,%s,%s)",
+            ("00000000-0000-0000-0000-000000000001", date(2026, 1, 10), "ACCUMULATION", "MARKUP", 5),
+        )
+        cur.execute(
+            "INSERT INTO public.wyckoff_sequences (ticker_id, sequence_id, start_date, completion_date, events_in_sequence) VALUES (%s,%s,%s,%s,%s)",
+            ("00000000-0000-0000-0000-000000000001", "SOS-LPS", date(2026, 1, 1), date(2026, 1, 10), Json(["SOS", "LPS"])),
+        )
+        cur.execute(
+            "INSERT INTO public.wyckoff_sequence_events (ticker_id, sequence_id, completion_date, event_type, event_date, event_role, event_order) VALUES (%s,%s,%s,%s,%s,%s,%s)",
+            ("00000000-0000-0000-0000-000000000001", "SOS-LPS", date(2026, 1, 10), "SOS", date(2026, 1, 9), "start", 1),
+        )
+        cur.execute(
+            "INSERT INTO public.wyckoff_context_events (ticker_id, event_date, event_type, prior_regime, context_label) VALUES (%s,%s,%s,%s,%s)",
+            ("00000000-0000-0000-0000-000000000001", date(2026, 1, 9), "SOS", "ACCUMULATION", "context"),
+        )
+        cur.execute(
+            "INSERT INTO public.wyckoff_snapshot_evidence (ticker_id, date, evidence_json) VALUES (%s,%s,%s)",
+            ("00000000-0000-0000-0000-000000000001", date(2026, 1, 10), Json({"confidence": 0.7})),
+        )
+    conn.commit()
+
+
+@pytest.fixture()
+def seeded_db(monkeypatch):
+    db_url = _test_db_url()
+    if not db_url:
+        pytest.skip("KAPMAN_TEST_DATABASE_URL is not set")
+
+    reset_and_migrate(db_url, default_migrations_dir())
+    with psycopg2.connect(db_url) as conn:
+        _seed(conn)
+
+    monkeypatch.setenv("DATABASE_URL", db_url)
+    return db_url
+
+
+def test_get_wyckoff_proposal_context_shape(seeded_db):
+    result = get_wyckoff_proposal_context("AMD", as_of_date="2026-01-10", lookback_days=30)
+    assert result["symbol"] == "AMD"
+    assert result["pipeline_reading"]["confirmation_status"] == "unconfirmed_pipeline_observation"
+    assert result["pipeline_reading"]["regime"] == "MARKUP"
+    assert result["data_quality_flags"]["duplicate_same_day_snapshots"] is True
+
+
+def test_get_metrics_filter_and_nulls(seeded_db):
+    result = get_metrics("AMD", include=["price", "technical"], metric_keys=["rvol", "missing_key"])
+    assert set(result["metrics"].keys()) == {"price", "technical"}
+    assert result["metrics"]["price"]["rvol"] == 1.8
+    assert result["metrics"]["technical"]["missing_key"] is None
+
+
+def test_screen_watchlist_filters_limit(seeded_db):
+    result = screen_watchlist(filters={"regime": ["MARKUP"], "dgpi_min": 0.5}, limit=1)
+    assert result["count"] == 1
+    assert len(result["results"]) == 1
+    assert result["results"][0]["symbol"] == "AMD"
+
+
+def test_missing_snapshot_and_missing_ohlcv_flags(seeded_db):
+    result = get_wyckoff_proposal_context("AMD", as_of_date="2025-01-01", lookback_days=30)
+    assert result["data_quality_flags"]["missing_snapshot"] is True
+    assert result["data_quality_flags"]["missing_ohlcv"] is True
+
+
+def test_no_writes_during_tool_calls(seeded_db):
+    with psycopg2.connect(seeded_db) as conn:
+        with conn.cursor() as cur:
+            cur.execute("SELECT COUNT(*) FROM public.daily_snapshots")
+            before = cur.fetchone()[0]
+
+    get_wyckoff_proposal_context("AMD", as_of_date="2026-01-10", lookback_days=30)
+    get_metrics("AMD")
+    screen_watchlist(limit=10)
+
+    with psycopg2.connect(seeded_db) as conn:
+        with conn.cursor() as cur:
+            cur.execute("SELECT COUNT(*) FROM public.daily_snapshots")
+            after = cur.fetchone()[0]
+
+    assert before == after

--- a/tests/unit/mcp/test_mcp_tools_unit.py
+++ b/tests/unit/mcp/test_mcp_tools_unit.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import pytest
+
+from core.mcp.tools.metrics import get_metrics
+from core.mcp.tools.screen_watchlist import screen_watchlist
+from core.mcp.tools.wyckoff_proposal import get_wyckoff_proposal_context
+
+
+def test_invalid_date_validation():
+    with pytest.raises(ValueError, match="YYYY-MM-DD"):
+        get_metrics("AMD", as_of_date="2026/01/01")
+
+
+def test_missing_symbol_validation():
+    with pytest.raises(ValueError, match="symbol is required"):
+        get_wyckoff_proposal_context("", lookback_days=90)
+
+
+def test_screen_limit_validation():
+    with pytest.raises(ValueError, match="limit"):
+        screen_watchlist(limit=0)
+
+
+def test_metrics_include_validation():
+    with pytest.raises(ValueError, match="unsupported include"):
+        get_metrics("AMD", include=["foo"])


### PR DESCRIPTION
## Summary
- adds a local read-only MCP server under `core/mcp`
- exposes `get_wyckoff_proposal_context`, `get_metrics`, and `screen_watchlist` tools
- documents local stdio client setup and adds MCP unit/integration tests

## Validation
- `PYTHONPATH=. venv/bin/python -m pytest tests/unit/mcp tests/integration/mcp`
- Result: 4 passed, 5 skipped (`KAPMAN_TEST_DATABASE_URL` is not set for DB-backed integration tests)

## Notes
- Excluded an accidental local Claude config file that contained a concrete `DATABASE_URL` value.